### PR TITLE
Third party router POC

### DIFF
--- a/server/core/src/main/scala/sttp/tapir/server/interpreter/ThirdPartyInterpreter.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interpreter/ThirdPartyInterpreter.scala
@@ -1,0 +1,11 @@
+package sttp.tapir.server.interpreter
+
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.interceptor.RequestResult
+import sttp.tapir.server.{model, _}
+
+trait ThirdPartyInterpreter[F[_]] {
+
+  def run[B, S](request: ServerRequest, fromRequestBody: RequestBody[F, S], toResponseBody: ToResponseBody[B, S]): F[RequestResult[B]]
+
+}


### PR DESCRIPTION
This is a POC to showcase an idea that would allow smithy4s to tap into various backends provided by tapir. 

* Adds a `ThirdPartyInterpreter` interface to `serverCore`
* Integrates the `ThirdPartyInterpreter` interface in http4s and jdkhttp